### PR TITLE
Add support for Laravel 5.1 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add a new disk to your `filesystems.php` config
     'key_file' => env('GOOGLE_CLOUD_KEY_FILE', null), // optional: /path/to/service-account.json
     'bucket' => env('GOOGLE_CLOUD_STORAGE_BUCKET', 'your-bucket'),
     'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', null), // optional: /default/path/to/apply/in/bucket
-    'storage_api_uri' => env('GOOGLE_CLOUD_STORAGE_API_URI', null),
+    'storage_api_uri' => env('GOOGLE_CLOUD_STORAGE_API_URI', null), // see: Public URLs below
 ],
 ```
 
@@ -53,6 +53,34 @@ The Google Client uses a few methods to determine how it should authenticate wit
 
 4. If running in **Google App Engine**, the built-in service account associated with the application will be used.
 5. If running in **Google Compute Engine**, the built-in service account associated with the virtual machine instance will be used.
+
+### Public URLs
+
+The adapter implements a `getUrl($path)` method which returns a public url to a file.
+
+```php
+$disk = Storage::disk('gcs');
+$url = $disk->url('folder/my_file.txt');
+>>> http://storage.googleapis.com/bucket-name/folder/my_file.txt
+```
+
+If you configure a `path_prefix` in your config:
+```php
+$disk = Storage::disk('gcs');
+$url = $disk->url('folder/my_file.txt');
+>>> http://storage.googleapis.com/bucket-name/path-prefix/folder/my_file.txt
+```
+
+If you configure a custom `storage_api_uri` in your config:
+```php
+$disk = Storage::disk('gcs');
+$url = $disk->url('folder/my_file.txt');
+>>> http://your-custom-domain.com/bucket-name/path-prefix/folder/my_file.txt
+```
+
+For a custom domain (storage api uri), you will need to configure a CNAME DNS entry pointing to `storage.googleapis.com`.
+
+Please see https://cloud.google.com/storage/docs/xml-api/reference-uris#cname for further instructions.
 
 ## Usage
 
@@ -74,5 +102,8 @@ $disk->copy('old/file1.jpg', 'new/file1.jpg');
 // move a file
 $disk->move('old/file1.jpg', 'new/file1.jpg');
 
-// see https://laravel.com/docs/5.1/filesystem for full list of available functionality
+// get url to file
+$url = $disk->url('folder/my_file.txt');
+
+// see https://laravel.com/docs/5.3/filesystem for full list of available functionality
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add a new disk to your `filesystems.php` config
     'key_file' => env('GOOGLE_CLOUD_KEY_FILE', null), // optional: /path/to/service-account.json
     'bucket' => env('GOOGLE_CLOUD_STORAGE_BUCKET', 'your-bucket'),
     'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', null), // optional: /default/path/to/apply/in/bucket
-    'storage_api_uri' => env('GOOGLE_CLOUD_STORAGE_API_URI', null), // see: Public URLs below
+    'storage_api_uri' => env('GOOGLE_CLOUD_STORAGE_API_URI', null),
 ],
 ```
 
@@ -53,34 +53,6 @@ The Google Client uses a few methods to determine how it should authenticate wit
 
 4. If running in **Google App Engine**, the built-in service account associated with the application will be used.
 5. If running in **Google Compute Engine**, the built-in service account associated with the virtual machine instance will be used.
-
-### Public URLs
-
-The adapter implements a `getUrl($path)` method which returns a public url to a file.
-
-```php
-$disk = Storage::disk('gcs');
-$url = $disk->url('folder/my_file.txt');
->>> http://storage.googleapis.com/bucket-name/folder/my_file.txt
-```
-
-If you configure a `path_prefix` in your config:
-```php
-$disk = Storage::disk('gcs');
-$url = $disk->url('folder/my_file.txt');
->>> http://storage.googleapis.com/bucket-name/path-prefix/folder/my_file.txt
-```
-
-If you configure a custom `storage_api_uri` in your config:
-```php
-$disk = Storage::disk('gcs');
-$url = $disk->url('folder/my_file.txt');
->>> http://your-custom-domain.com/bucket-name/path-prefix/folder/my_file.txt
-```
-
-For a custom domain (storage api uri), you will need to configure a CNAME DNS entry pointing to `storage.googleapis.com`.
-
-Please see https://cloud.google.com/storage/docs/xml-api/reference-uris#cname for further instructions.
 
 ## Usage
 
@@ -102,8 +74,5 @@ $disk->copy('old/file1.jpg', 'new/file1.jpg');
 // move a file
 $disk->move('old/file1.jpg', 'new/file1.jpg');
 
-// get url to file
-$url = $disk->url('folder/my_file.txt');
-
-// see https://laravel.com/docs/5.3/filesystem for full list of available functionality
+// see https://laravel.com/docs/5.1/filesystem for full list of available functionality
 ```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The Google Client uses a few methods to determine how it should authenticate wit
 ### Public URLs
 
 The adapter implements a `getUrl($path)` method which returns a public url to a file.
+>**Note:** Method available for Laravel 5.2 and higher. If used on 5.1, it will throw an exception.
 
 ```php
 $disk = Storage::disk('gcs');
@@ -105,5 +106,5 @@ $disk->move('old/file1.jpg', 'new/file1.jpg');
 // get url to file
 $url = $disk->url('folder/my_file.txt');
 
-// see https://laravel.com/docs/5.3/filesystem for full list of available functionality
+// See https://laravel.com/docs/5.3/filesystem for full list of available functionality
 ```

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/support": "^5.2|^5.3",
+    "illuminate/support": "^5.1|^5.2|^5.3",
     "superbalist/flysystem-google-storage": "^3.0|^4.0",
-    "illuminate/filesystem": "^5.2|^5.3"
+    "illuminate/filesystem": "^5.1|^5.2|^5.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
@matthewgoslett What do you think about creating a branch to support Laravel 5.1?

This PR allows the installation on 5.1 and also updates the readme.
I just tested out on my app and everything seems to work well, except that the **url() method** will not work because it was introduced until L5.2+

The reason to this is that there are many companies that cannot rely their backend on versions that are not LTS. Currently my case.

So the idea is to create a new branch and merge this PR on top of that.
Also it would be nice to link/mention the new branch on the current readme so everyone can switch to it if they need to.