### PR TITLE
Enable provider autodiscovery on Laravel 5.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ This package is a wrapper bridging [flysystem-google-storage](https://github.com
 composer require superbalist/laravel-google-cloud-storage
 ```
 
-Register the service provider in app.php
+If you are on Laravel 5.4 or earlier, then register the service provider in app.php
 ```php
 'providers' => [
     // ...
     Superbalist\LaravelGoogleCloudStorage\GoogleCloudStorageServiceProvider::class,
 ]
 ```
+
+If you are on Laravel 5.5 or higher, composer will have registered the provider automatically for you.
 
 Add a new disk to your `filesystems.php` config
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
   "extra": {
     "branch-alias": {
       "dev-master": "1.0-dev"
+    },
+    "laravel": {
+      "providers": [
+        "Superbalist\\LaravelGoogleCloudStorage\\GoogleCloudStorageServiceProvider"
+      ]
     }
   },
   "require-dev": {


### PR DESCRIPTION
This change supports package autodiscovery in Laravel 5.5+ making installation just that little bit easier.