### PR TITLE
Allow configuring the disk's visibility and cache as with S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Add a new disk to your `filesystems.php` config
     'bucket' => env('GOOGLE_CLOUD_STORAGE_BUCKET', 'your-bucket'),
     'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', null), // optional: /default/path/to/apply/in/bucket
     'storage_api_uri' => env('GOOGLE_CLOUD_STORAGE_API_URI', null), // see: Public URLs below
+    'visibility' => 'public', // optional: public|private
 ],
 ```
 


### PR DESCRIPTION
This allows configuring the optional `visibility`, `disable_asserts` and `url` options on the filesystem, as well as adding a caching layer around the adapter.

The main benefit of this would be to be able to configure the disk's visibility the same way as if using a S3 disk.

See: [Laravel's FilesystemManager::createFlysystem()](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Filesystem/FilesystemManager.php#L271).