### PR TITLE
Cache support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "php": ">=5.5.9",
     "illuminate/support": "^5.1|^5.2|^5.3",
     "superbalist/flysystem-google-storage": ">=3.0 <8.0",
-    "illuminate/filesystem": "^5.1|^5.2|^5.3"
+    "illuminate/filesystem": "^5.1|^5.2|^5.3",
+    "league/flysystem-cached-adapter": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -2,13 +2,15 @@
 
 namespace Superbalist\LaravelGoogleCloudStorage;
 
-use Google\Cloud\Storage\StorageClient;
-use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Support\Arr;
-use Illuminate\Support\ServiceProvider;
-use League\Flysystem\AdapterInterface;
-use League\Flysystem\Cached\CachedAdapter;
+use Illuminate\Filesystem\Cache;
 use League\Flysystem\Filesystem;
+use League\Flysystem\AdapterInterface;
+use Illuminate\Support\ServiceProvider;
+use Google\Cloud\Storage\StorageClient;
+use League\Flysystem\Cached\CachedAdapter;
+use Illuminate\Filesystem\FilesystemManager;
+use League\Flysystem\Cached\Storage\Memory as MemoryStore;
 use Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter;
 
 class GoogleCloudStorageServiceProvider extends ServiceProvider
@@ -16,8 +18,8 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
     /**
      * Create a Filesystem instance with the given adapter.
      *
-     * @param  \League\Flysystem\AdapterInterface  $adapter
-     * @param  array  $config
+     * @param  \League\Flysystem\AdapterInterface $adapter
+     * @param  array $config
      * @return \League\Flysystem\FlysystemInterfaceAdapterInterface
      */
     protected function createFilesystem(AdapterInterface $adapter, array $config)
@@ -33,10 +35,10 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
         return new Filesystem($adapter, count($config) > 0 ? $config : null);
     }
 
-     /**
+    /**
      * Create a cache store instance.
      *
-     * @param  mixed  $config
+     * @param  mixed $config
      * @return \League\Flysystem\Cached\CacheInterface
      *
      * @throws \InvalidArgumentException
@@ -59,7 +61,8 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $factory = $this->app->make('filesystem'); /* @var FilesystemManager $factory */
+        $factory = $this->app->make('filesystem');
+        /* @var FilesystemManager $factory */
         $factory->extend('gcs', function ($app, $config) {
             $storageClient = new StorageClient([
                 'projectId' => $config['project_id'],

--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -33,6 +33,27 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
         return new Filesystem($adapter, count($config) > 0 ? $config : null);
     }
 
+     /**
+     * Create a cache store instance.
+     *
+     * @param  mixed  $config
+     * @return \League\Flysystem\Cached\CacheInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function createCacheStore($config)
+    {
+        if ($config === true) {
+            return new MemoryStore;
+        }
+
+        return new Cache(
+            $this->app['cache']->store($config['store']),
+            $config['prefix'] ?? 'flysystem',
+            $config['expire'] ?? null
+        );
+    }
+
     /**
      * Perform post-registration booting of services.
      */


### PR DESCRIPTION
Fixes the following error when you enable cache.
`Call to undefined method Superbalist\LaravelGoogleCloudStorage\GoogleCloudStorageServiceProvider::createCacheStore()`

This error shows up when using version 2.1.0 and Laravel version 5.7.