### PR TITLE
No longer compatible with older than PHP 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": ">=5.5.9",
+    "php": ">=7.0.0",
     "illuminate/support": "^5.1|^5.2|^5.3",
     "superbalist/flysystem-google-storage": ">=3.0 <8.0",
     "illuminate/filesystem": "^5.1|^5.2|^5.3",


### PR DESCRIPTION
Use of the null coalescing operator means PHP 7.0 is required.