### PR TITLE
fixed syntax error

### DIFF
--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -95,7 +95,7 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
             'projectId' => $config['project_id'],
             'keyFile' => array_merge([
                 "project_id" => $config['project_id']
-            ], array_get($config, 'key_file', [])
+            ], array_get($config, 'key_file', []))
         ]);
     }
 


### PR DESCRIPTION
```
In GoogleCloudStorageServiceProvider.php line 99:
                                                      
  syntax error, unexpected ']', expecting ',' or ')'  
                                                      

Script @php artisan package:discover handling the post-autoload-dump event returned with error code 1
```  
