### PR TITLE
Fix #60 - rewrite for createClient()

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Add a new disk to your `filesystems.php` config
 'gcs' => [
     'driver' => 'gcs',
     'project_id' => env('GOOGLE_CLOUD_PROJECT_ID', 'your-project-id'),
-    'key_file' => env('GOOGLE_CLOUD_KEY_FILE', null), // optional: /path/to/service-account.json
+    'key_file_path' => env('GOOGLE_CLOUD_KEY_FILE', null), // optional: /path/to/service-account.json
+    'key_file' => null, // optional: Array of data that substitutes the .json file (see below)
     'bucket' => env('GOOGLE_CLOUD_STORAGE_BUCKET', 'your-bucket'),
     'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', null), // optional: /default/path/to/apply/in/bucket
     'storage_api_uri' => env('GOOGLE_CLOUD_STORAGE_API_URI', null), // see: Public URLs below
@@ -44,7 +45,7 @@ Add a new disk to your `filesystems.php` config
 
 The Google Client uses a few methods to determine how it should authenticate with the Google API.
 
-1. If you specify a path in the key `key_file` in  disk config, that json credentials file will be used.
+1. If you specify a path in the key `key_file_path` in  disk config, that json credentials file will be used.
 2. If the `GOOGLE_APPLICATION_CREDENTIALS` env var is set, it will use that.
    ```php
    putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json');

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.2 - 2019-05-13
+
+* Fix #60: `json key is missing the type field`.
+
+* Support key_file_path and key_file separately (conforms with GCS class)
+
+* Fix issue where in every case a key_file was given, breaking built-in service accounts
+
+* Updated README with key_file, and key_file_path
+
 ## 2.2.1 - 2019-04-18
 
 * Fix #57: `ErrorException thrown with message "array_merge(): Argument #2 is not an array"` when defining service account


### PR DESCRIPTION
First off, great work to the creators and or maintainers. I've relied on this project for a few years on numerous projects, it's been awesome, I'm glad that I can contribute here.

The issue started when key_file was allowed to be an array, the code was changed and we ran into the original array_merge issue #57 & #59 that I had created. The error was that array_merge would throw an exception that its given parameters could not be null. The fix was to write an is_array check, and if it failed then it would set $keyFile to an empty array.

While this fixed the array_merge issue, it did not fix the underlying problem, which was that the code, currently, will always return a new StorageClient with a key_file. Even if it is null, as long as the key 'key_file' exists the constructor array, the Google\Cloud\Storage\StorageClient will try to look for it, and it will fail throwing null errors on missing or incorrect data. This prevents and breaks all built-in service accounts from working without explicitly setting a .json file.

Now the key_file parameter (while it may work if a file path is passed into it, not sure) is actually for passing in the config in an array directly (like it says in the laravel-google-cloud-storage readme), and key_file_path is for the file path of the json file that Google\Cloud\Storage\StorageClient->Google\Cloud\Core\ClientTrait::getKeyFile() will read and run a `json_decode(file_get_contents(key_file_path)` on to get an array of parameters.

I rewrote createClient() to do the following (in pseudo code below)

`
get from config key_file_path
if is_string(key_file_path) and key_file_path is not empty()
    Give us our storage client and tell Google to use our key_file_path file

if that fails

get from config key_file
if is_array(key_file) and key_file_path is not empty()
    Give us our storage client and tell Google to use our key_file array as its config

if that fails

Give us our storage client and tell google we don't have any configuration to give it
`

Now that since Google didn't receive any configuration (given key_file_path and key_file are null), it searches on its own (GOOGLE_APPLICATION_CREDENTIALS, well known OS specific files, and built-in service accounts). With this patch, everything works as expected from the README.

That should bring this issue to a close. Sorry if my php-cs-fixer formatted the code base. It was automatic. I updated the readme to reflect the changes in the config, to match the new code, as well as updating the changelog.
