### PR TITLE
bugfix: allow authentication with automatic GCP discovery

### DIFF
--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -84,21 +84,24 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
      */
     private function createClient($config)
     {
-        $keyFile = array_get($config, 'key_file');
-        if (is_string($keyFile)) {
-            return new StorageClient([
-                'projectId' => $config['project_id'],
-                'keyFilePath' => $keyFile,
-            ]);
+        $options = [];
+        if (isset($config['project_id'])) {
+            $options['projectId'] = $config['project_id'];
         }
 
-        if (! is_array($keyFile)) {
-            $keyFile = [];
+        if (isset($config['key_file'])) {
+            $keyFile = array_get($config, 'key_file');
+            if (is_string($keyFile)) {
+                $options['keyFilePath'] = $keyFile;
+            } else {
+                if (! is_array($keyFile)) {
+                    $keyFile = [];
+                }
+                $options['keyFile'] = array_merge(["project_id" => $config['project_id']], $keyFile);
+            }
         }
-        return new StorageClient([
-            'projectId' => $config['project_id'],
-            'keyFile' => array_merge(["project_id" => $config['project_id']], $keyFile)
-        ]);
+
+        return new StorageClient($options);
     }
 
     /**


### PR DESCRIPTION
Google ProjectID and Credentials (keyfile) are not necessary when the application is running inside GCP (as noted in https://github.com/googleapis/google-cloud-php/blob/master/AUTHENTICATION.md)
Currently the package forces the user to provide a project ID and credentials when if it is not necessary, forcing the user to extra IAM management such as creating a service account.