### PR TITLE
Add support for the 'metadata' config option

### DIFF
--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -26,7 +26,7 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
     {
         $cache = Arr::pull($config, 'cache');
 
-        $config = Arr::only($config, ['visibility', 'disable_asserts', 'url']);
+        $config = Arr::only($config, ['visibility', 'disable_asserts', 'url', 'metadata']);
 
         if ($cache) {
             $adapter = new CachedAdapter($adapter, $this->createCacheStore($cache));


### PR DESCRIPTION
Support for this was added in the main package [Superbalist/flysystem-google-cloud-storage](https://github.com/Superbalist/flysystem-google-cloud-storage), but was not added to this laravel integration yet. This PR fixes that.

The commit that added metadata support to the other repo is https://github.com/Superbalist/flysystem-google-cloud-storage/commit/fedbdca5a6d2491c57bb9685d33e6f46726240fe