### PR TITLE
Allow environment variable KEY_FILE to be null

### DIFF
--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -85,6 +85,14 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
     private function createClient($config)
     {
         $keyFile = Arr::get($config, 'key_file');
+        
+        if (is_null($keyFile)) {
+            return new StorageClient([
+                'projectId' => $config['project_id'],
+                'keyFilePath' => $keyFile,
+            ]);
+        }
+        
         if (is_string($keyFile)) {
             return new StorageClient([
                 'projectId' => $config['project_id'],

--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -89,7 +89,6 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
         if (is_null($keyFile)) {
             return new StorageClient([
                 'projectId' => $config['project_id'],
-                'keyFilePath' => $keyFile,
             ]);
         }
         


### PR DESCRIPTION
This is in line with the documentation for Superbalist Google Cloud Storage Flysystem Adapter.