### PR TITLE
Allow use with GCP service account; fixes #60

### DIFF
--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -85,19 +85,16 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
     private function createClient($config)
     {
         $keyFile = Arr::get($config, 'key_file');
-        if (is_string($keyFile)) {
+        if (is_array($keyFile)) {
             return new StorageClient([
                 'projectId' => $config['project_id'],
-                'keyFilePath' => $keyFile,
+                'keyFile' => array_merge(["project_id" => $config['project_id']], $keyFile)
             ]);
         }
 
-        if (! is_array($keyFile)) {
-            $keyFile = [];
-        }
         return new StorageClient([
             'projectId' => $config['project_id'],
-            'keyFile' => array_merge(["project_id" => $config['project_id']], $keyFile)
+            'keyFilePath' => $keyFile
         ]);
     }
 


### PR DESCRIPTION
Re-rolled from https://github.com/ralfiannor/laravel-google-cloud-storage/tree/patch-1; credit to @ralfiannor for the original patch, which I confirmed as working from awhile back.